### PR TITLE
fix: 修复日期筛选无效的bug，确保用户能够正确筛选指定时区的日期

### DIFF
--- a/src/views/proTable/tradeQuery/auth/index.tsx
+++ b/src/views/proTable/tradeQuery/auth/index.tsx
@@ -174,13 +174,12 @@ const Auth = () => {
 		let startDate = undefined;
 		let endDate = undefined;
 		if (dates) {
-			startDate = dates[0].format("YYYY-MM-DD");
-			startDate.setHours(0, 0, 0, 0);
+			startDate = new Date(dates[0]);
+			startDate = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate(), 0, 0, 0, 0));
 
-			endDate = dates[1].format("YYYY-MM-DD");
-			endDate.setHours(23, 59, 59, 999);
+			endDate = new Date(dates[1]);
+			endDate = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate(), 23, 59, 59, 999));
 		}
-
 		setSearchTransactionRequest({
 			...searchTransactionRequest,
 			where: {

--- a/src/views/proTable/tradeQuery/create/index.tsx
+++ b/src/views/proTable/tradeQuery/create/index.tsx
@@ -123,7 +123,13 @@ const Create = () => {
 	];
 
 	const handleTimeChange = (dates: any) => {
-		setSelectedTimeRange(dates ? [dates[0].format("YYYY-MM-DD"), dates[1].format("YYYY-MM-DD")] : []);
+		if (dates) {
+			let startDate = new Date(dates[0]);
+			startDate = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate(), 0, 0, 0, 0));
+			let endDate = new Date(dates[1]);
+			endDate = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate(), 23, 59, 59, 999));
+			setSelectedTimeRange([startDate, endDate]);
+		}
 	};
 
 	const handleCardTypeChange = (value: string[]) => {
@@ -211,8 +217,8 @@ const Create = () => {
 		let adjustedEnd: number | undefined = undefined;
 		if (selectedTimeRange.length > 0) {
 			const [start, end] = selectedTimeRange;
-			adjustedStart = new Date(start).setHours(0, 0, 0, 0);
-			adjustedEnd = new Date(end).setHours(23, 59, 59, 999);
+			adjustedStart = start;
+			adjustedEnd = end;
 		}
 		fetchUserCards(1, TRANSACTION_DEFAULT_PAGE_SIZE, adjustedStart, adjustedEnd);
 	};

--- a/src/views/proTable/tradeQuery/transactions/index.tsx
+++ b/src/views/proTable/tradeQuery/transactions/index.tsx
@@ -153,8 +153,12 @@ const Aransactions = () => {
 	// Update selected date range
 	const handleTimeChange = (dates: any) => {
 		if (dates) {
-			searchTransferRequest.where!.startDate = dates[0].valueOf();
-			searchTransferRequest.where!.endDate = dates[1].valueOf();
+			let startDate = new Date(dates[0]);
+			startDate = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate(), 0, 0, 0, 0));
+			let endDate = new Date(dates[1]);
+			endDate = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate(), 23, 59, 59, 999));
+			searchTransferRequest.where!.startDate = startDate;
+			searchTransferRequest.where!.endDate = endDate;
 		} else {
 			searchTransferRequest.where!.startDate = undefined;
 			searchTransferRequest.where!.endDate = undefined;


### PR DESCRIPTION
修复日期筛选无效的bug，确保用户能够正确筛选指定时区的日期